### PR TITLE
Configure changelog generation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - C-dependency
+      - R-ignore

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,34 @@
+---
+- name: C-bug
+  color: e74c3c
+  description: "Report a new bug"
+- name: C-dependency
+  color: e74c3c
+  description: "Update a dependency"
+- name: C-documentation
+  color: e74c3c
+  description: "Improve the documentation"
+- name: C-feature-request
+  color: e74c3c
+  description: "Request a new feature"
+- name: R-added
+  color: 95a5a6
+  description: "Add a new feature to the release notes"
+- name: R-changed
+  color: 95a5a6
+  description: "Add a change in existing functionality to the release notes"
+- name: R-deprecated
+  color: 95a5a6
+  description: "Add a soon-to-be removed feature to the release notes"
+- name: R-fixed
+  color: 95a5a6
+  description: "Add a fixed bug to the release notes"
+- name: R-ignore
+  color: 95a5a6
+  description: "Do not add this pull request to the release notes"
+- name: R-removed
+  color: 95a5a6
+  description: "Add a now removed feature to the release notes"
+- name: R-security
+  color: 95a5a6
+  description: "Add a vulnerability warning to the release notes"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+---
+changelog:
+  exclude:
+    labels:
+      - R-ignore
+    authors:
+      - dependabot
+  categories:
+    - title: Security
+      labels:
+        - R-security
+    - title: Added
+      labels:
+        - R-added
+    - title: Changed
+      labels:
+        - R-changed
+    - title: Deprecated
+      labels:
+        - R-deprecated
+    - title: Removed
+      labels:
+        - R-removed
+    - title: Fixed
+      labels:
+        - R-fixed

--- a/.github/workflows/push-maintenance.yml
+++ b/.github/workflows/push-maintenance.yml
@@ -1,0 +1,23 @@
+---
+name: Maintenance
+
+"on":
+  push:
+    branches:
+      - main
+
+jobs:
+  labels:
+    name: Sync labels
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Sync labels
+        uses: micnncim/action-label-syncer@v1.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manifest: .github/labels.yml


### PR DESCRIPTION
GitHub can generate changelogs for releases based on the activity in the
repository. The feature has been configured to follow the style of Keep
a Changelog [^1], and the necessary labels have been added to the
repository.

[^1]: https://keepachangelog.com