### PR TITLE
Add attribution to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ If the `version` is not specified, the latest version will be installed.
 👋 This is a welcoming and inclusive project. Be nice and follow our
 [code of conduct](./CODE_OF_CONDUCT.md).
 
+## Acknowledgments
+
+The implementation of this action is inspired by
+[actions/setup-node](https://github.com/actions/setup-node) and
+[bufbuild/buf-setup-action](https://github.com/bufbuild/buf-setup-action).
+
 ## License
 
 This project is released under the terms of the [MIT License](./LICENSE).


### PR DESCRIPTION
setup-butler has been built with inspiration from setup-node and
buf-setup-action. Both are mentioned in the README to give proper
attribution.