### PR TITLE
Optionally allow dependency updates in changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,8 +3,6 @@ changelog:
   exclude:
     labels:
       - R-ignore
-    authors:
-      - dependabot
   categories:
     - title: Security
       labels:


### PR DESCRIPTION
The rules for the auto-generated changelog have been modified to allow adding dependency updates to the release notes.