### PR TITLE
Switch from Dependabot to Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base", ":disableDependencyDashboard"],
+  "semanticCommits": "disabled"
+}


### PR DESCRIPTION
We are replacing Dependabot with Renovate, which offers more customization and flexibility. A configuration with sensible defaults has been added to the repository. Features that I do not like have been turned off.