### PR TITLE
Restore TypeScript workflows

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,0 +1,29 @@
+---
+name: TypeScript
+
+"on":
+  push:
+    branches:
+      - main
+    paths:
+      - "package.json"
+      - "package-lock.json"
+      - "**.ts"
+  pull_request:
+    paths:
+      - "package.json"
+      - "package-lock.json"
+      - "**.ts"
+
+jobs:
+  lint:
+    name: Lint
+    uses: ./.github/workflows/typescript-lint.yml
+
+  style:
+    name: Style
+    uses: ./.github/workflows/typescript-style.yml
+
+  test:
+    name: Test
+    uses: ./.github/workflows/typescript-test.yml


### PR DESCRIPTION
When switching the workflows to the shared repository, the workflows for TypeScript got dropped by accident. The functionality has been restored.