### PR TITLE
Run macOS tests on x86 runner

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-latest
+          - macos-13
           - ubuntu-latest
           - windows-latest
 


### PR DESCRIPTION
GitHub recently updated `macos-latest` to the new M1-based runners. This broke CI, since Butler is not yet available for `arm64` based architectures. The macOS runner has therefore been locked to the latest version still using the `x86` architecture.