### PR TITLE
Update Node version to latest LTS

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-node@v4.0.3
         with:
           cache: npm
-          node-version: 16
+          node-version: 20
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/setup-node@v4.0.3
         with:
           cache: npm
-          node-version: 16
+          node-version: 20
 
       - name: Install dependencies
         run: npm install
@@ -72,7 +72,7 @@ jobs:
         uses: actions/setup-node@v4.0.3
         with:
           cache: npm
-          node-version: 16
+          node-version: 20
 
       - name: Install dependencies
         run: npm install
@@ -95,7 +95,7 @@ jobs:
         uses: actions/setup-node@v4.0.3
         with:
           cache: npm
-          node-version: 16
+          node-version: 20
 
       - name: Install dependencies
         run: npm install

--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ inputs:
     default: "latest"
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
The version of Node that is used both for running the action and testing it on GitHub Actions has been bumped to Node 20, the latest LTS.