### PR TITLE
Trigger GitHub Actions consistently

### DIFF
--- a/.github/flowcrafter.yml
+++ b/.github/flowcrafter.yml
@@ -1,5 +1,4 @@
 library:
   github:
-    instance: https://api.github.com/
     owner: jdno
     repository: workflows

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -3,6 +3,10 @@ name: Action
 
 "on":
   push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   # The repository contains the action itself in the dist/ directory. Whenever

--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -6,6 +6,7 @@ name: JSON
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -6,6 +6,7 @@ name: Markdown
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -6,6 +6,7 @@ name: TypeScript
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -6,6 +6,7 @@ name: YAML
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:


### PR DESCRIPTION
All GitHub Actions used for continuous integration are now triggered in the same way. This ensures that all relevant actions run on every pull request, irrespective whether the pull request was opened from a fork or not.